### PR TITLE
Add support for drag/drop to OBS

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,7 +778,17 @@ if (urlParams.has('streamid')){
 	}
 }
 
-
+document.addEventListener("dragstart", e => {
+	var url = e.target.href || e.target.data;
+	if (!url || !url.startsWith('http')) return;
+	var streamId = url.split('=')[1];
+	url += '&layer-name=OBS.Ninja';
+	if (streamId) url += ': ' + streamId;
+	var video = document.getElementById('videosource');
+	url += '&layer-width=' + video.videoWidth;
+	url += '&layer-height=' + video.videoHeight;
+	e.dataTransfer.setData("text/uri-list", encodeURI(url));
+});
 
 var vis = (function(){
 	var stateKey, eventKey, keys = {


### PR DESCRIPTION
Uses methods [described here](https://obsproject.com/tools/browser-drag-and-drop) to support dragging the link directly into OBS with a friendly source name, and width/height based on the actual source video.

My recommendation would be a fancier button and putting the parameters behind it that way, but more complex implementation can always be discussed later.

Example gif:
![2020-03-23_18-42-59](https://user-images.githubusercontent.com/941350/77293350-3f8ba780-6d36-11ea-898b-7eaec7ce400a.gif)
