### PR TITLE
Fix logic in `toggleMute`

### DIFF
--- a/main.js
+++ b/main.js
@@ -1031,9 +1031,9 @@ window.onmessage = function(e){ // iFRAME support
 	
 	if ("mic" in e.data){
 		if (e.data.mic == true){
-			toggleMute(true);
-		} else if (e.data.mic == false){
 			toggleMute(false);
+		} else if (e.data.mic == false){
+			toggleMute(true);
 		} else if (e.data.mic == "toggle"){
 			toggleMute();
 		} 

--- a/main.js
+++ b/main.js
@@ -1350,11 +1350,12 @@ function updateStats(obsvc=false){
 
 
 function toggleMute(apply=false){ // TODO: I need to have this be MUTE, toggle, with volume not touched.
-	if (apply){
+	if (apply==undefined){
 		session.muted=!session.muted;
+	} else {
+		session.muted=apply;
 	}
-	if (session.muted==false){
-		session.muted = true;
+	if (session.muted==true){
 		getById("mutetoggle").className="las la-microphone-slash my-float toggleSize";
 		getById("mutebutton").className="float2";
 		
@@ -1362,9 +1363,7 @@ function toggleMute(apply=false){ // TODO: I need to have this be MUTE, toggle, 
 		  track.enabled = false;
 		});
 		
-	} else{
-		session.muted=false;
-		
+	} else {
 		getById("mutetoggle").className="las la-microphone my-float toggleSize";
 		getById("mutebutton").className="float";
 		

--- a/main.js
+++ b/main.js
@@ -1349,7 +1349,7 @@ function updateStats(obsvc=false){
 }
 
 
-function toggleMute(apply=false){ // TODO: I need to have this be MUTE, toggle, with volume not touched.
+function toggleMute(apply){ // TODO: I need to have this be MUTE, toggle, with volume not touched.
 	if (apply==undefined){
 		session.muted=!session.muted;
 	} else {


### PR DESCRIPTION
Previously, calling `toggleMute()` and `toggleMute(false)` would both alternate `session.muted` while `toggleMute(true)` did nothing. Now, `toggleMute()` alternates `session.muted` while `toggleMute(false)` and `toggleMute(true)` set it to the given value.

The new behavior is based on what I see the `window.onmessage` implementation trying to do when it receives a message like `{"mic": [true|false|"toggle"]}`