### PR TITLE
ES6 conversion for translate.js

### DIFF
--- a/translations/translate.js
+++ b/translations/translate.js
@@ -2,20 +2,22 @@
 
 function downloadTranslation(filename, trans={}){  // downloads the current translation to a file
 	
-	var textDoc = JSON.stringify(trans, null, 2);
+	const textDoc = JSON.stringify(trans, null, 2);
 
-	var hiddenElement = document.createElement('a');
-	hiddenElement.href = 'data:text/html,' + encodeURIComponent(textDoc);
+    const hiddenElement = document.createElement('a');
+    
+	hiddenElement.href = `data:text/html,${encodeURIComponent(textDoc)}`;
 	hiddenElement.target = '_blank';
-	hiddenElement.download = filename+".json";
-	hiddenElement.click();
+	hiddenElement.download = `${filename}.json`;
+    hiddenElement.click();
+    
 	return trans;
 }
 
 
 function updateTranslation(filename){  // updates the website with a specific translation
-	var request = new XMLHttpRequest();
-	request.open('GET', "./translations/"+filename+'.json?'+(Math.random()*100).toString(), false);  // `false` makes the request synchronous
+	const request = new XMLHttpRequest();
+	request.open('GET', `./translations/${filename}.json?${(Math.random() * 100).toString()}`, false);  // `false` makes the request synchronous
 	request.send(null);
 
 	if (request.status !== 200) {
@@ -29,26 +31,28 @@ function updateTranslation(filename){  // updates the website with a specific tr
 		return false, {};
 	}
 	
-	var oldTransItems = data.innerHTML;  
-	var allItems1 = document.querySelectorAll('[data-translate]');
+	const oldTransItems = data.innerHTML;  
+    const allItems1 = document.querySelectorAll('[data-translate]');
+    
 	allItems1.forEach(function(ele){
 		if (ele.dataset.translate in oldTransItems){
 			ele.innerHTML = oldTransItems[ele.dataset.translate];
 		}
-	});
-	var oldTransTitles = data.titles;
-	var allTitles1 = document.querySelectorAll('[title]');
+    });
+    
+	const oldTransTitles = data.titles;
+	const allTitles1 = document.querySelectorAll('[title]');
 	allTitles1.forEach(function(ele){
-		var key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
+		const key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
 		if (key in oldTransTitles){
 			ele.title = oldTransTitles[key];
 		}
 	});
 	
-	var oldTransPlaceholders = data.placeholders; 
-	var allPlaceholders1 = document.querySelectorAll('[placeholder]');
+	const oldTransPlaceholders = data.placeholders; 
+	const allPlaceholders1 = document.querySelectorAll('[placeholder]');
 	allPlaceholders1.forEach(function(ele){
-		var key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
+		const key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
 		if (key in oldTransPlaceholders){
 			ele.placeholder = oldTransPlaceholders[key];
 		}
@@ -57,60 +61,60 @@ function updateTranslation(filename){  // updates the website with a specific tr
 	return [true, data];
 }
 
-var updateList = ["cs","de", "en", "es", "fr", "it", "ja", "nl", "pig", "pt", "ru", "tr", "blank" ];  // list of languages to update. Update this if you add a new language.
+const updateList = ["cs","de", "en", "es", "fr", "it", "ja", "nl", "pig", "pt", "ru", "tr", "blank" ];  // list of languages to update. Update this if you add a new language.
 
-var allItems = document.querySelectorAll('[data-translate]');
-var defaultTrans = {};
+const allItems = document.querySelectorAll('[data-translate]');
+const defaultTrans = {};
 allItems.forEach(function(ele){
-	var key = ele.dataset.translate.replace(/[\W]+/g,"-").toLowerCase();
+	const key = ele.dataset.translate.replace(/[\W]+/g,"-").toLowerCase();
 	defaultTrans[key] = ele.innerHTML;
 });
 
-var defaultTransTitles = {};
-var allTitles = document.querySelectorAll('[title]');
+const defaultTransTitles = {};
+const allTitles = document.querySelectorAll('[title]');
 allTitles.forEach(function(ele){
 	defaultTransTitles[ele.title] = ele.title;
 });
 
-var defaultTransPlaceholders = {};
-var allPlaceholders = document.querySelectorAll('[placeholder]');
+const defaultTransPlaceholders = {};
+const allPlaceholders = document.querySelectorAll('[placeholder]');
 allPlaceholders.forEach(function(ele){
 	defaultTransPlaceholders[ele.placeholder] = ele.placeholder;
 });
 
-var combinedTrans = {}
+const combinedTrans = {}
 combinedTrans.titles = defaultTransTitles;
 combinedTrans.innerHTML = defaultTrans;
 combinedTrans.placeholders = defaultTransPlaceholders;
 var counter=0;
-for (var i in updateList){
-	var lang = updateList[i];
+for (const i in updateList){
+	const lang = updateList[i];
 	setTimeout(function(ln){
 		var suceess = updateTranslation(ln); // we don't need to worry about DATA.
 		if (suceess[0]==true){
-			var newTrans = suceess[1].innerHTML;
-			var allItems = document.querySelectorAll('[data-translate]');
+			const newTrans = suceess[1].innerHTML;
+			const allItems = document.querySelectorAll('[data-translate]');
 			allItems.forEach(function(ele){
-				var key = ele.dataset.translate;
+				const key = ele.dataset.translate;
 				newTrans[key] = ele.innerHTML;
 			});
 			
-			var newTransTitles = suceess[1].titles;
-			var allTitles = document.querySelectorAll('[title]');
+			const newTransTitles = suceess[1].titles;
+			const allTitles = document.querySelectorAll('[title]');
 			allTitles.forEach(function(ele){
-				var key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
+				const key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
 				newTransTitles[key] = ele.title;
 			});
 			
-			var newPlaceholders = suceess[1].placeholders;
-			var allPlaceholders = document.querySelectorAll('[placeholder]');
+			const newPlaceholders = suceess[1].placeholders;
+			const allPlaceholders = document.querySelectorAll('[placeholder]');
 			allPlaceholders.forEach(function(ele){
-				var key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
+				const key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
 				newPlaceholders[key] = ele.placeholder;
 			});
 			
 			////// DOWNLOAD UPDATED TRANSLATION
-			var outputTrans = {}
+			const outputTrans = {}
 			outputTrans.titles = newTransTitles;
 			outputTrans.innerHTML = newTrans;
 			outputTrans.placeholders = newPlaceholders;
@@ -123,13 +127,13 @@ for (var i in updateList){
 			}
 		});
 		allTitles.forEach(function(ele){
-			var key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
+			const key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
 			if (key in defaultTransTitles){
 				ele.title = defaultTransTitles[key];
 			}
 		});
 		allPlaceholders.forEach(function(ele){
-			var key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
+			const key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
 			if (key in defaultTransPlaceholders){
 				ele.placeholder = defaultTransPlaceholders[key];
 			}

--- a/translations/translate.js
+++ b/translations/translate.js
@@ -1,143 +1,143 @@
 // Copy and paste this code into OBS.Ninja's developer's console to generate new Translation files
 
-function downloadTranslation(filename, trans={}){  // downloads the current translation to a file
-	
-	const textDoc = JSON.stringify(trans, null, 2);
+function downloadTranslation(filename, trans = {}) {  // downloads the current translation to a file
+
+    const textDoc = JSON.stringify(trans, null, 2);
 
     const hiddenElement = document.createElement('a');
-    
-	hiddenElement.href = `data:text/html,${encodeURIComponent(textDoc)}`;
-	hiddenElement.target = '_blank';
-	hiddenElement.download = `${filename}.json`;
+
+    hiddenElement.href = `data:text/html,${encodeURIComponent(textDoc)}`;
+    hiddenElement.target = '_blank';
+    hiddenElement.download = `${filename}.json`;
     hiddenElement.click();
-    
-	return trans;
+
+    return trans;
 }
 
 
-function updateTranslation(filename){  // updates the website with a specific translation
-	const request = new XMLHttpRequest();
-	request.open('GET', `./translations/${filename}.json?${(Math.random() * 100).toString()}`, false);  // `false` makes the request synchronous
-	request.send(null);
+function updateTranslation(filename) {  // updates the website with a specific translation
+    const request = new XMLHttpRequest();
+    request.open('GET', `./translations/${filename}.json?${(Math.random() * 100).toString()}`, false);  // `false` makes the request synchronous
+    request.send(null);
 
-	if (request.status !== 200) {
-	  return false, {};
-	}
-	try{
-		var data = JSON.parse(request.responseText);
-	} catch(e){
-		console.log(request.responseText);
-		console.error(e);
-		return false, {};
-	}
-	
-	const oldTransItems = data.innerHTML;  
+    if (request.status !== 200) {
+        return false, {};
+    }
+    try {
+        var data = JSON.parse(request.responseText);
+    } catch (e) {
+        console.log(request.responseText);
+        console.error(e);
+        return false, {};
+    }
+
+    const oldTransItems = data.innerHTML;
     const allItems1 = document.querySelectorAll('[data-translate]');
-    
-	allItems1.forEach(function(ele){
-		if (ele.dataset.translate in oldTransItems){
-			ele.innerHTML = oldTransItems[ele.dataset.translate];
-		}
+
+    allItems1.forEach(function (ele) {
+        if (ele.dataset.translate in oldTransItems) {
+            ele.innerHTML = oldTransItems[ele.dataset.translate];
+        }
     });
-    
-	const oldTransTitles = data.titles;
-	const allTitles1 = document.querySelectorAll('[title]');
-	allTitles1.forEach(function(ele){
-		const key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
-		if (key in oldTransTitles){
-			ele.title = oldTransTitles[key];
-		}
-	});
-	
-	const oldTransPlaceholders = data.placeholders; 
-	const allPlaceholders1 = document.querySelectorAll('[placeholder]');
-	allPlaceholders1.forEach(function(ele){
-		const key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
-		if (key in oldTransPlaceholders){
-			ele.placeholder = oldTransPlaceholders[key];
-		}
-	});
-	
-	return [true, data];
+
+    const oldTransTitles = data.titles;
+    const allTitles1 = document.querySelectorAll('[title]');
+    allTitles1.forEach(function (ele) {
+        const key = ele.title.replace(/[\W]+/g, "-").toLowerCase();
+        if (key in oldTransTitles) {
+            ele.title = oldTransTitles[key];
+        }
+    });
+
+    const oldTransPlaceholders = data.placeholders;
+    const allPlaceholders1 = document.querySelectorAll('[placeholder]');
+    allPlaceholders1.forEach(function (ele) {
+        const key = ele.placeholder.replace(/[\W]+/g, "-").toLowerCase();
+        if (key in oldTransPlaceholders) {
+            ele.placeholder = oldTransPlaceholders[key];
+        }
+    });
+
+    return [true, data];
 }
 
-const updateList = ["cs","de", "en", "es", "fr", "it", "ja", "nl", "pig", "pt", "ru", "tr", "blank" ];  // list of languages to update. Update this if you add a new language.
+const updateList = ["cs", "de", "en", "es", "fr", "it", "ja", "nl", "pig", "pt", "ru", "tr", "blank"];  // list of languages to update. Update this if you add a new language.
 
 const allItems = document.querySelectorAll('[data-translate]');
 const defaultTrans = {};
-allItems.forEach(function(ele){
-	const key = ele.dataset.translate.replace(/[\W]+/g,"-").toLowerCase();
-	defaultTrans[key] = ele.innerHTML;
+allItems.forEach(function (ele) {
+    const key = ele.dataset.translate.replace(/[\W]+/g, "-").toLowerCase();
+    defaultTrans[key] = ele.innerHTML;
 });
 
 const defaultTransTitles = {};
 const allTitles = document.querySelectorAll('[title]');
-allTitles.forEach(function(ele){
-	defaultTransTitles[ele.title] = ele.title;
+allTitles.forEach(function (ele) {
+    defaultTransTitles[ele.title] = ele.title;
 });
 
 const defaultTransPlaceholders = {};
 const allPlaceholders = document.querySelectorAll('[placeholder]');
-allPlaceholders.forEach(function(ele){
-	defaultTransPlaceholders[ele.placeholder] = ele.placeholder;
+allPlaceholders.forEach(function (ele) {
+    defaultTransPlaceholders[ele.placeholder] = ele.placeholder;
 });
 
 const combinedTrans = {}
 combinedTrans.titles = defaultTransTitles;
 combinedTrans.innerHTML = defaultTrans;
 combinedTrans.placeholders = defaultTransPlaceholders;
-var counter=0;
-for (const i in updateList){
-	const lang = updateList[i];
-	setTimeout(function(ln){
-		var suceess = updateTranslation(ln); // we don't need to worry about DATA.
-		if (suceess[0]==true){
-			const newTrans = suceess[1].innerHTML;
-			const allItems = document.querySelectorAll('[data-translate]');
-			allItems.forEach(function(ele){
-				const key = ele.dataset.translate;
-				newTrans[key] = ele.innerHTML;
-			});
-			
-			const newTransTitles = suceess[1].titles;
-			const allTitles = document.querySelectorAll('[title]');
-			allTitles.forEach(function(ele){
-				const key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
-				newTransTitles[key] = ele.title;
-			});
-			
-			const newPlaceholders = suceess[1].placeholders;
-			const allPlaceholders = document.querySelectorAll('[placeholder]');
-			allPlaceholders.forEach(function(ele){
-				const key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
-				newPlaceholders[key] = ele.placeholder;
-			});
-			
-			////// DOWNLOAD UPDATED TRANSLATION
-			const outputTrans = {}
-			outputTrans.titles = newTransTitles;
-			outputTrans.innerHTML = newTrans;
-			outputTrans.placeholders = newPlaceholders;
-			downloadTranslation(ln, outputTrans);
-		} 
-		  ////////// RESET THING BACK
-		allItems.forEach(function(ele){
-			if (ele.dataset.translate in defaultTrans){
-				ele.innerHTML = defaultTrans[ele.dataset.translate];
-			}
-		});
-		allTitles.forEach(function(ele){
-			const key = ele.title.replace(/[\W]+/g,"-").toLowerCase();
-			if (key in defaultTransTitles){
-				ele.title = defaultTransTitles[key];
-			}
-		});
-		allPlaceholders.forEach(function(ele){
-			const key = ele.placeholder.replace(/[\W]+/g,"-").toLowerCase();
-			if (key in defaultTransPlaceholders){
-				ele.placeholder = defaultTransPlaceholders[key];
-			}
-		});
-	},counter,lang);
-	counter+=300;
+var counter = 0;
+for (const i in updateList) {
+    const lang = updateList[i];
+    setTimeout(function (ln) {
+        var suceess = updateTranslation(ln); // we don't need to worry about DATA.
+        if (suceess[0] == true) {
+            const newTrans = suceess[1].innerHTML;
+            const allItems = document.querySelectorAll('[data-translate]');
+            allItems.forEach(function (ele) {
+                const key = ele.dataset.translate;
+                newTrans[key] = ele.innerHTML;
+            });
+
+            const newTransTitles = suceess[1].titles;
+            const allTitles = document.querySelectorAll('[title]');
+            allTitles.forEach(function (ele) {
+                const key = ele.title.replace(/[\W]+/g, "-").toLowerCase();
+                newTransTitles[key] = ele.title;
+            });
+
+            const newPlaceholders = suceess[1].placeholders;
+            const allPlaceholders = document.querySelectorAll('[placeholder]');
+            allPlaceholders.forEach(function (ele) {
+                const key = ele.placeholder.replace(/[\W]+/g, "-").toLowerCase();
+                newPlaceholders[key] = ele.placeholder;
+            });
+
+            ////// DOWNLOAD UPDATED TRANSLATION
+            const outputTrans = {}
+            outputTrans.titles = newTransTitles;
+            outputTrans.innerHTML = newTrans;
+            outputTrans.placeholders = newPlaceholders;
+            downloadTranslation(ln, outputTrans);
+        }
+        ////////// RESET THING BACK
+        allItems.forEach(function (ele) {
+            if (ele.dataset.translate in defaultTrans) {
+                ele.innerHTML = defaultTrans[ele.dataset.translate];
+            }
+        });
+        allTitles.forEach(function (ele) {
+            const key = ele.title.replace(/[\W]+/g, "-").toLowerCase();
+            if (key in defaultTransTitles) {
+                ele.title = defaultTransTitles[key];
+            }
+        });
+        allPlaceholders.forEach(function (ele) {
+            const key = ele.placeholder.replace(/[\W]+/g, "-").toLowerCase();
+            if (key in defaultTransPlaceholders) {
+                ele.placeholder = defaultTransPlaceholders[key];
+            }
+        });
+    }, counter, lang);
+    counter += 300;
 }

--- a/translations/translate.js
+++ b/translations/translate.js
@@ -1,12 +1,14 @@
 // Copy and paste this code into OBS.Ninja's developer's console to generate new Translation files
 
-function downloadTranslation(filename, trans = {}) {  // downloads the current translation to a file
+function downloadTranslation(filename, trans = {}) { // downloads the current translation to a file
 
     const textDoc = JSON.stringify(trans, null, 2);
 
     const hiddenElement = document.createElement('a');
 
-    hiddenElement.href = `data:text/html,${encodeURIComponent(textDoc)}`;
+    hiddenElement.href = `data:text/html,${
+        encodeURIComponent(textDoc)
+    }`;
     hiddenElement.target = '_blank';
     hiddenElement.download = `${filename}.json`;
     hiddenElement.click();
@@ -15,9 +17,11 @@ function downloadTranslation(filename, trans = {}) {  // downloads the current t
 }
 
 
-function updateTranslation(filename) {  // updates the website with a specific translation
+function updateTranslation(filename) { // updates the website with a specific translation
     const request = new XMLHttpRequest();
-    request.open('GET', `./translations/${filename}.json?${(Math.random() * 100).toString()}`, false);  // `false` makes the request synchronous
+    request.open('GET', `./translations/${filename}.json?${
+        (Math.random() * 100).toString()
+    }`, false); // `false` makes the request synchronous
     request.send(null);
 
     if (request.status !== 200) {
@@ -34,7 +38,7 @@ function updateTranslation(filename) {  // updates the website with a specific t
     const oldTransItems = data.innerHTML;
     const allItems1 = document.querySelectorAll('[data-translate]');
 
-    allItems1.forEach(function (ele) {
+    allItems1.forEach((ele) => {
         if (ele.dataset.translate in oldTransItems) {
             ele.innerHTML = oldTransItems[ele.dataset.translate];
         }
@@ -42,7 +46,7 @@ function updateTranslation(filename) {  // updates the website with a specific t
 
     const oldTransTitles = data.titles;
     const allTitles1 = document.querySelectorAll('[title]');
-    allTitles1.forEach(function (ele) {
+    allTitles1.forEach((ele) => {
         const key = ele.title.replace(/[\W]+/g, "-").toLowerCase();
         if (key in oldTransTitles) {
             ele.title = oldTransTitles[key];
@@ -51,7 +55,7 @@ function updateTranslation(filename) {  // updates the website with a specific t
 
     const oldTransPlaceholders = data.placeholders;
     const allPlaceholders1 = document.querySelectorAll('[placeholder]');
-    allPlaceholders1.forEach(function (ele) {
+    allPlaceholders1.forEach((ele) => {
         const key = ele.placeholder.replace(/[\W]+/g, "-").toLowerCase();
         if (key in oldTransPlaceholders) {
             ele.placeholder = oldTransPlaceholders[key];
@@ -61,24 +65,38 @@ function updateTranslation(filename) {  // updates the website with a specific t
     return [true, data];
 }
 
-const updateList = ["cs", "de", "en", "es", "fr", "it", "ja", "nl", "pig", "pt", "ru", "tr", "blank"];  // list of languages to update. Update this if you add a new language.
+const updateList = [
+    "cs",
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "ja",
+    "nl",
+    "pig",
+    "pt",
+    "ru",
+    "tr",
+    "blank"
+]; // list of languages to update. Update this if you add a new language.
 
 const allItems = document.querySelectorAll('[data-translate]');
 const defaultTrans = {};
-allItems.forEach(function (ele) {
+allItems.forEach((ele) => {
     const key = ele.dataset.translate.replace(/[\W]+/g, "-").toLowerCase();
     defaultTrans[key] = ele.innerHTML;
 });
 
 const defaultTransTitles = {};
 const allTitles = document.querySelectorAll('[title]');
-allTitles.forEach(function (ele) {
+allTitles.forEach((ele) => {
     defaultTransTitles[ele.title] = ele.title;
 });
 
 const defaultTransPlaceholders = {};
 const allPlaceholders = document.querySelectorAll('[placeholder]');
-allPlaceholders.forEach(function (ele) {
+allPlaceholders.forEach((ele) => {
     defaultTransPlaceholders[ele.placeholder] = ele.placeholder;
 });
 
@@ -89,50 +107,50 @@ combinedTrans.placeholders = defaultTransPlaceholders;
 var counter = 0;
 for (const i in updateList) {
     const lang = updateList[i];
-    setTimeout(function (ln) {
+    setTimeout((ln) => {
         var suceess = updateTranslation(ln); // we don't need to worry about DATA.
         if (suceess[0] == true) {
             const newTrans = suceess[1].innerHTML;
             const allItems = document.querySelectorAll('[data-translate]');
-            allItems.forEach(function (ele) {
+            allItems.forEach((ele) => {
                 const key = ele.dataset.translate;
                 newTrans[key] = ele.innerHTML;
             });
 
             const newTransTitles = suceess[1].titles;
             const allTitles = document.querySelectorAll('[title]');
-            allTitles.forEach(function (ele) {
+            allTitles.forEach((ele) => {
                 const key = ele.title.replace(/[\W]+/g, "-").toLowerCase();
                 newTransTitles[key] = ele.title;
             });
 
             const newPlaceholders = suceess[1].placeholders;
             const allPlaceholders = document.querySelectorAll('[placeholder]');
-            allPlaceholders.forEach(function (ele) {
+            allPlaceholders.forEach((ele) => {
                 const key = ele.placeholder.replace(/[\W]+/g, "-").toLowerCase();
                 newPlaceholders[key] = ele.placeholder;
             });
 
-            ////// DOWNLOAD UPDATED TRANSLATION
-            const outputTrans = {}
+            // //// DOWNLOAD UPDATED TRANSLATION
+            const outputTrans = {};
             outputTrans.titles = newTransTitles;
             outputTrans.innerHTML = newTrans;
             outputTrans.placeholders = newPlaceholders;
             downloadTranslation(ln, outputTrans);
         }
-        ////////// RESET THING BACK
-        allItems.forEach(function (ele) {
+        // //////// RESET THING BACK
+        allItems.forEach((ele) => {
             if (ele.dataset.translate in defaultTrans) {
                 ele.innerHTML = defaultTrans[ele.dataset.translate];
             }
         });
-        allTitles.forEach(function (ele) {
+        allTitles.forEach((ele) => {
             const key = ele.title.replace(/[\W]+/g, "-").toLowerCase();
             if (key in defaultTransTitles) {
                 ele.title = defaultTransTitles[key];
             }
         });
-        allPlaceholders.forEach(function (ele) {
+        allPlaceholders.forEach((ele) => {
             const key = ele.placeholder.replace(/[\W]+/g, "-").toLowerCase();
             if (key in defaultTransPlaceholders) {
                 ele.placeholder = defaultTransPlaceholders[key];

--- a/translations/translate.js
+++ b/translations/translate.js
@@ -100,10 +100,11 @@ allPlaceholders.forEach((ele) => {
     defaultTransPlaceholders[ele.placeholder] = ele.placeholder;
 });
 
-const combinedTrans = {}
+const combinedTrans = {};
 combinedTrans.titles = defaultTransTitles;
 combinedTrans.innerHTML = defaultTrans;
 combinedTrans.placeholders = defaultTransPlaceholders;
+
 var counter = 0;
 for (const i in updateList) {
     const lang = updateList[i];


### PR DESCRIPTION
Convert most variables in translate.js to be better understood and convert callback functions to arrow functions (). All browsers that support WebRTC should also support these.

Arrow functions: 95.47% usage. [Can I use](https://caniuse.com/arrow-functions)
![caniuse chart](https://user-images.githubusercontent.com/29888641/101367970-e2755900-38a6-11eb-937e-80c22148d699.png)

Const variables: 99.16% usage. [Can I use](https://caniuse.com/const)
![caniuse chart](https://user-images.githubusercontent.com/29888641/101368121-10f33400-38a7-11eb-969b-0131f1c71ba9.png)

