### PR TITLE
Fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1048,7 +1048,7 @@
 					<i class="las la-circle"></i>
 					<span data-translate="record"> Record</span>
 				</button>
-				<button class="advanced" data-action-type="voice-chat" title="Toggle Voice Chat with this Guest"">
+				<button class="advanced" data-action-type="voice-chat" title="Toggle Voice Chat with this Guest">
 					<span data-translate="voice-chat"><i class="las la-microphone"></i> Voice Chat</span>
 				</button>
 				


### PR DESCRIPTION
I realized why a giant chunk of the file was failing to highlight correctly.