### PR TITLE
Feature: &rooms

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
 					<i class="toggleSize my-float las la-dot-circle" style="position: relative;" aria-hidden="true"></i>
 				</div>
 				<span id="miniPerformer" style="pointer-events: auto;" class="advanced"></span>
+				<span id="rooms" style="padding-top:3px;pointer-events: auto;color:#fff;"></span>
 				
 				<div id="hangupbutton2" onmousedown="event.preventDefault(); event.stopPropagation();"  title="Cancel the Director's Video/Audio"  onclick="hangup2()" class="advanced float"  tabindex="25" role="button" aria-pressed="false" onkeyup="enterPressedClick(event,this);" style="cursor: pointer;" alt="Disconnect Direcotor's cam">
 					<i class="toggleSize my-float las la-phone rotate225" aria-hidden="true"></i>

--- a/main.css
+++ b/main.css
@@ -501,10 +501,23 @@ button.glyphicon-button.active.focus {
 		padding: 0px;
 	} 
 }
+/* Node selector to prioritise this selector above .float */
+button.btnArmTransferRoom{
+    width:auto;
+    margin-left: 2px;
+    height:38px;
+    border-radius: 15px;
+}
+button.btnArmTransferRoom i{
+    margin-right:3px;
+}
+button.btnArmTransferRoom:hover{
+    background-color: var(--green-accent);
+}
 
-
-
-
+button.btnArmTransferRoom.selected{
+    background-color: var(--red-accent);
+}
 
 @media only screen and (max-height: 540px){
 	#subControlButtons {

--- a/main.js
+++ b/main.js
@@ -707,6 +707,11 @@ if (urlParams.has('director') || urlParams.has('dir')) {
 	filename = false;
 }
 
+if (urlParams.has('rooms')) {
+    session.rooms = urlParams.get('rooms').split(",").map(function(e) { 
+        return sanitizeRoomName(e);
+    });
+}
 
 if (urlParams.has('showdirector')) {
 	session.showDirector = true;
@@ -3718,6 +3723,7 @@ function lowerhand() {
 var previousRoom = "";
 var stillNeedRoom = true;
 var transferCancelled = false;
+var armedTransfer = true;
 
 function directMigrate(ele, event) { // everyone in the room will hangup this guest also?  I like that idea.  What about the STREAM ID?  I suppose we don't kick out if the viewID matches.
 
@@ -3741,6 +3747,8 @@ function directMigrate(ele, event) { // everyone in the room will hangup this gu
 		stillNeedRoom = false;
 		log("Migrate queued");
 		return;
+    } else if (armedTransfer){
+		migrateRoom = sanitizeRoomName(previousRoom);
 	} else {
 		var migrateRoom = prompt("Transfer guests to room:\n\n(Please note rooms must share the same password)", previousRoom);
 		stillNeedRoom = true;
@@ -4990,6 +4998,18 @@ function createRoomCallback(passAdd, passAdd2) {
 			getById("miniPerformer").innerHTML = '<button id="press2talk" onmousedown="event.preventDefault(); event.stopPropagation();" style="width:auto;margin-left:5px;height:45px;border-radius: 38px;" class="float" onclick="press2talk(true);" title="You can also enable the director`s Video Output afterwards by clicking the Setting`s button"><i class="las la-headset"></i><span data-translate="push-to-talk-enable"> enable director`s microphone or video</span></button>';
 		}
 		getById("miniPerformer").className = "";
+        
+        var tabindex = 26;
+        if(session.rooms && session.rooms.length > 0){
+            var container = getById("rooms");
+            container.innerHTML += 'Arm Transfer: ';
+            session.rooms.forEach(function (r) {
+                if(session.roomid == r) return; //don't include self
+                container.innerHTML += '<button id="roomselect_' + r + '" onmousedown="event.preventDefault(); event.stopPropagation();" class="float btnArmTransferRoom" onclick="handleRoomSelect(\'' + r + '\');" title="Arm/disarm transfer to this room" tabindex="' + tabindex + '"><i class="las la-paper-plane"></i>' + r + '</button>';
+                tabindex++;
+            });
+        }
+        
 	} else {
 		getById("miniPerformer").style.display = "none";
 		getById("controlButtons").style.display = "none";
@@ -5004,6 +5024,26 @@ function createRoomCallback(passAdd, passAdd2) {
 
 	joinRoom(session.roomid);
 
+}
+/**
+ * Handles click actions on the room selection buttons in #controlButtons
+ * @param {string} room - Room name to select/deselect for the next transfer call
+ */
+function handleRoomSelect(room) {
+    var elems = document.querySelectorAll(".btnArmTransferRoom");
+    [].forEach.call(elems, function(el) {
+        el.classList.remove("selected");
+    });
+    if (previousRoom == room) {
+        previousRoom = undefined;
+        armedTransfer = false;
+        stillNeedRoom = true;
+    } else {
+        previousRoom = room;
+        stillNeedRoom = false;
+        armedTransfer = true;
+        getById("roomselect_" + room).classList.add('selected');
+    }
 }
 
 function requestAudioSettings(ele) {


### PR DESCRIPTION
Permits a list of rooms to be defined for room transfer operations. Buttons are added to the control bar, when selected and a transfer button is pushed the user will be transferred straight to that room rather than the room name having to be entered. 

Parameter &rooms accepts a comma-separated list of room names to include as options, if the current room is included then it will be ignored.

Example of control bar shown below:

<img width="640" alt="Example Room Selection" src="https://user-images.githubusercontent.com/4053079/107125367-7a8cc000-68a1-11eb-942b-2cd1fc289423.png">

Have used this with users at this end in the last few days, they preferred it to the first attempt using a pop-up which involves additional interaction to achieve the same. 

Don't believe I can include wiki edits in a pull request but will update if this is accepted, equally, of course, happy to take another run at it if there are coding or phrasing bits that need looking at.