### PR TITLE
screenshare audio selector panel tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,9 +428,9 @@
 						<br />
 					</center>
 					<p id="audioScreenShare1">
+						<i class="las la-microphone-alt"></i>
 						<span data-translate="audio-sources">Audio Sources</span>
-						<br />
-						<select id="audioSourceScreenshare" multiple  alt="tip: Hold CTRL (command) to select Multiple" title="tip: Hold CTRL (command) to select Multiple"  style="height: 60px; min-width: 290px; resize: both; overflow: auto; padding: 5px;" onchange="requestAudioStream();">
+						<select id="audioSourceScreenshare" multiple  alt="tip: Hold CTRL (command) to select Multiple" title="tip: Hold CTRL (command) to select Multiple" onchange="requestAudioStream();">
 							<option value="screenshare" selected>
 								Screen Share Audio (default)
 							</option>

--- a/main.css
+++ b/main.css
@@ -1066,6 +1066,33 @@ input[type=range]:focus::-ms-fill-upper {
 	z-index: 1;
 }
 
+#audioSourceScreenshare {
+	display:block;
+	height: 60px;
+	min-width: 290px;
+	overflow: auto;
+	padding: 5px;
+	resize: both;
+}
+
+p#audioScreenShare1 {
+    border: 1px solid #ccc;
+    display: inline-block;
+    background: #f3f3f3;
+    padding: 4px 10px 10px 10px;
+	text-align: left;
+}
+
+#audioScreenShare1 > i {
+    display: inline-block;
+}
+
+#audioScreenShare1 > span {
+    margin: 7px 0px;
+    text-align: left;
+    display: inline-block;
+}
+
 h2 {
 	color: white;
 	-webkit-user-select: none;


### PR DESCRIPTION
- extract inline styles to main.css
- The audio selector panel is now similar to the one from the video camera sharing section