### PR TITLE
Configuration for Turn-Servers with static-auth-secret

### DIFF
--- a/index.html
+++ b/index.html
@@ -1577,6 +1577,19 @@
             // turn.urls = ["turn:turn2.obs.ninja:443"]; // US WEST
             // session.configuration.iceServers.push(turn);
 
+			// uncomment this section if you plan to do the configuration in index.php as index file, e.g., to use a turn-server that uses use-auth-secret and static-auth-secret
+            // session.configuration = {
+            //   iceServers: [
+            //        { urls: ["xxx_stun_servers_xxx"] }, // xxx_stun-server_xxx will be automatically replaced by index.php
+            //   ],
+			//   sdpSemantics: 'unified-plan'
+            //};
+            //var turn = {};
+            //turn.username = "xxx_username_xxx"; // username will be generated in index.php; xxx_username_xxx will be automatically replaced
+            //turn.credential = "xxx_password_xxx"; // password generated in index.php; xxx_password_xxx will be automatically replaced
+            //turn.urls = ["xxx_turn_servers_xxx"]; // xxx_turn-server_xxx will be automatically replaced by index.php
+            //session.configuration.iceServers.push(turn);
+
             // session.configuration.iceTransportPolicy = "relay";  // uncomment to enable "&privacy" and force the TURN server
 
 			///// Different endpoints are available; each isolated from each other.

--- a/index.php
+++ b/index.php
@@ -1,0 +1,21 @@
+<?php
+	$stun_server = "stun:<stun-server>:3478";
+	$turn_server = "turn:<turn-server>:5349";
+	$turn_expiry = 86400;
+	$turn_username = time() + $turn_expiry;
+	$turn_secret = '<static-auth-secret from turn-server config>';
+	$turn_password = base64_encode ( hash_hmac ( 'sha1', $turn_username, $turn_secret, true ) );
+
+	function callback($buffer)
+	{
+		global $stun_server, $turn_server, $turn_username, $turn_password;
+		$buffer = str_replace("xxx_stun_servers_xxx", $stun_server, $buffer);
+		$buffer = str_replace("xxx_turn_servers_xxx", $turn_server, $buffer);
+		$buffer = str_replace("xxx_username_xxx", $turn_username, $buffer);
+		$buffer = str_replace("xxx_password_xxx", $turn_password, $buffer);
+		return ($buffer);
+	}
+	ob_start("callback");
+	include 'index.html';
+	ob_end_flush();
+?>


### PR DESCRIPTION
I use a turn server with a static-auth-secret and turn-server and applications are generating username and password from the same secret. Username and password are valid only for a certain time and will get invalid after an expiry time. This does not necessarily prevent other people from using your turn-server (since they could always read an up-to-date password from the html code of your application) but it prevents other applications to rely on your turn-server since they do not know the secret to generate new passwords.

Since it is not possible to implement this in html, I created an index.php file that will generate the username and the password. It then includes the index.html and rewrites the values. By this, the secret stays in the index.php and will not be published anywhere.

index.html
added a section that can simply be uncommented with the configuration that will be rewritten by index.php

index.php
will generate username and password for a turn server with a static-auth-secret and will rewrite these values into index.html