### PR TITLE
correct link to advanced documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
 							</div>
 						</div>
 						<div>See the 
-							<a style="text-decoration: none; color: blue;" target="_blank" href="https://docs.obs.ninja/advanced">documentation</a> for more options and info.
+							<a style="text-decoration: none; color: blue;" target="_blank" href="https://docs.obs.ninja/advanced-settings">documentation</a> for more options and info.
 						</div>
 					</div>
 				</div>
@@ -1506,7 +1506,7 @@
 		<div id="screenPopup" class="popup-screen">
 			<button onclick="getById('screenPopup').style.display='none';margin:0;padding:0;">Close Window</button>
 			<div>See the 
-				<a style="text-decoration: none; color: blue;" target="_blank" href="https://docs.obs.ninja/advanced">documentation</a> for more options and info.
+				<a style="text-decoration: none; color: blue;" target="_blank" href="https://docs.obs.ninja/advanced-settings">documentation</a> for more options and info.
 			</div>
 		
 		</div>


### PR DESCRIPTION
The link to advanced documentation from the "Create Reusable Invite" (and from one other page) has pointed to a non-existing page (https://docs.obs.ninja/advanced). I pointed it to: https://docs.obs.ninja/advanced-settings .