### PR TITLE
Add a dedicated Refresh button

### DIFF
--- a/index.html
+++ b/index.html
@@ -2349,11 +2349,10 @@
 			</u>
 		</div>
 		<span class="hidden" id="hangupTemplate">
-			<span style='font-size:500%;text-align:center;margin:auto;'>👋</span>
+			<span style='font-size:500%;text-align:center;margin:auto;'>👋<br><button onClick='parent.location.reload();' title="Reload the page" data-translate="reload-page">Refresh</button></span>
 		</span>
 		<span class="hidden" id="hangupTemplateMobileFullscreen">
-			<span style='font-size:500%;text-align:center;margin:auto;'>👋<br ><a onclick="history.go(0);" title="Reload the page" data-translate="reload-page">Reload Page</a>
-			</span>
+			<span style='font-size:500%;text-align:center;margin:auto;'>👋<br><button onClick='parent.location.reload();' title="Reload the page" data-translate="reload-page">Refresh</button></span>
 		</span>
 		<div id="meshcastMenu" class="hidden">
 			Meshcast publishing region: <select name="edgelist" id="edgelist" onchange="selectMeshcast(this);" title="Select a location that is closest to both you and your audience."></select>


### PR DESCRIPTION
The original onclick="history.go(0);" method only forces the browser to reload the page from the cache. But if we use iframes, that will not work as expected if we try/debug different parameters in URL(iframed). This dedicated button uses location.reload() method, which will reload the current URL in the parent window of the current frame. This will cause the entire parent window, including any frames or iframes, to reload, reflecting any changes made to the page. 

PS: my first github pull-request, yeah! Still need to learn more JavaScript tho.