### PR TITLE
Fix generated input ids for boolean inputs

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -31834,7 +31834,7 @@ function updateDirectorsAudio(dataN, UUID) {
 		if (data.equalizer && n == 0) {
 			var label = document.createElement("label");
 			var i = "Low_EQ";
-			//label.id = "label_" +i + "_"+UUID;
+			//label.id = "label_" + i + "_"+UUID;
 			label.htmlFor = "constraints_" + i + "_" + UUID;
 
 			var input = document.createElement("input");
@@ -32720,9 +32720,9 @@ function updateDirectorsVideo(data, UUID) {
 			} else if (typeof data.cameraConstraints[i] === "boolean") {
 				var div = document.createElement("div");
 				var label = document.createElement("label");
-				label.id = "label_" + +i + "_" + UUID;
+				label.id = "label_" + i + "_" + UUID;
 				label.name = label.id;
-				label.htmlFor = "constraints_" + +i + "_" + UUID;
+				label.htmlFor = "constraints_" + i + "_" + UUID;
 				label.innerText = capitalizeFirstLetter(i).replace(/([a-z])([A-Z])/g, "$1 $2") + ":";
 				label.style = "display:inline-block; padding:0;";
 				label.dataset.keyname = i;
@@ -32741,7 +32741,7 @@ function updateDirectorsVideo(data, UUID) {
 					}
 				} catch (e) {}
 
-				input.id = "constraints_" + +i + "_" + UUID;
+				input.id = "constraints_" + i + "_" + UUID;
 				input.className = "constraintCameraInput";
 				input.name = input.id;
 				input.style = "display:inline; padding:2px;";


### PR DESCRIPTION
This doesn't seem to break nor fix any functionality, but I only have one boolean constraint, so can't fully check.

For torch On/Off input the generated HTML before:
```html
<div>
  <label id="label_NaN_{{some_uuid}}" for="constraints_NaN_{{some_uuid}}" data-keyname="torch" data--u-u-i-d="{{some_uuid}}" style="display: inline-block; padding: 0px;">Torch:</label>
  <select id="constraints_NaN_{{some_uuid}}" class="constraintCameraInput" name="constraints_NaN_{{some_uuid}}" data--u-u-i-d="{{some_uuid}}" data-keyname="torch" data-chosen="false" style="display: inline; padding: 2px;">
    <option value="false">Off</option>
    <option value="true">On</option>
  </select>
</div>
```

after
```html
<div>
  <label id="label_torch_{{some_uuid}}" for="constraints_torch_{{some_uuid}}" data-keyname="torch" data--u-u-i-d="{{some_uuid}}" style="display: inline-block; padding: 0px;">Torch:</label>
  <select id="constraints_torch_{{some_uuid}}" class="constraintCameraInput" name="constraints_torch_{{some_uuid}}" data--u-u-i-d="{{some_uuid}}" data-keyname="torch" data-chosen="false" style="display: inline; padding: 2px;">
    <option value="false">Off</option>
    <option value="true">On</option>
  </select>
</div>
```