### PR TITLE
&feedbackbutton tweak

### DIFF
--- a/main.js
+++ b/main.js
@@ -155,7 +155,12 @@ async function main() {
 	
 	if (urlParams.has("feedbackbutton") || urlParams.has("fb")) {
 		getById("unmuteSelf").classList.remove("hidden"); // lets the director see the avatar option
-		session.selfVolume = urlParams.get("fb") || null;
+		//session.selfVolume = urlParams.get("fb") || null;
+		session.selfVolume = urlParams.get("feedbackbutton") || urlParams.get("fb") || null;
+		if (session.selfVolume){
+			getById("unmuteSelf").setAttribute("title", `Hear yourself at ${parseFloat(session.selfVolume)}% volume`);
+			getById("unmuteSelf").setAttribute("alt", `Hear yourself at ${parseFloat(session.selfVolume)}% volume`);
+		}
 	}
 
 	if (urlParams.has("controls") || urlParams.has("videocontrols")) {


### PR DESCRIPTION
A small tweak for &feedbackbutton
(1) The &feedbackbutton only accept value by &fb (e.g., &fb=50), but &feedbackbutton=50 won't work. With this patch, both way will work. 
(2) The button prompt info always show "Hear yourself at 50% volume" without dynamic showing the real user defined &fb or &feedbackbutton value. With this patch, the showing can sync with the user assigned value.