### PR TITLE
Fix: Language reorder by time zone

### DIFF
--- a/main.js
+++ b/main.js
@@ -7805,11 +7805,23 @@ async function main() {
 	});
 
 	var currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
+	
 	if (timezones.includes(currentTimezone)) {
-		var el = getById("languagesList").querySelector("li a[data-tz*='" + currentTimezone + "']"); // select language li
-		el.parentElement.removeChild(el); // remove it
-		getById("languagesList").insertBefore(el, getById("languagesList").querySelector("li:nth-child(2)")); // insert it after English
+		var list = getById("languagesList");
+		// Find the link element matching the timezone
+		var el = list.querySelector("li a[data-tz*='" + currentTimezone + "']");
+	
+		if (el) {
+			var targetLi = el.parentElement; // Get the parent <li>
+			var firstLi = list.querySelector("li:first-child"); // Get the first li (English)
+	
+			// Only move if it's not already the first or second element
+			if (targetLi && firstLi && targetLi !== firstLi && targetLi !== firstLi.nextSibling) {
+				// Insert the <li> after the first element (English)
+				list.insertBefore(targetLi, firstLi.nextSibling);
+				// The original <li> is automatically removed from its old position when inserted elsewhere.
+			}
+		}
 	}
 
 	var visAudioTimeout = null;


### PR DESCRIPTION
"Avaiable Languages" menu order is changed when the visitor´s platform concide with a translated version.

![image](https://github.com/user-attachments/assets/82b670d4-2569-4606-abef-a39b787f4b17)

In my case, I live in Spain so the "Spanish" option went up to the second of the list. But not with the parent object.

Each option is in a `<li>` object, but the code when tries to reorder the options it gets only the `<a>` element causing this:

![alt text](https://github.com/user-attachments/assets/2c1145da-6739-4124-91db-49391927d95e)

After the code change, the menu for non-English speakers looks like this:
![image](https://github.com/user-attachments/assets/ca0181ba-3929-463b-9068-7ef90b59f32a)