### PR TITLE
Fix SI-prefixes (mbps -> Mbps)

### DIFF
--- a/dock.html
+++ b/dock.html
@@ -228,7 +228,7 @@ document.addEventListener("dragstart", event => {
 	<br /><br />
 	
 	
-	<input type="checkbox" id="invite_bitrate" /><label for="invite_bitrate"> <span data-translate="unlock-video-bitrate">Unlock Video Bitrate (20mbps)</span></label>
+	<input type="checkbox" id="invite_bitrate" /><label for="invite_bitrate"> <span data-translate="unlock-video-bitrate">Unlock Video Bitrate (20 Mbps)</span></label>
 	<br />
 	<input type="checkbox" id="invite_vp9" onclick="getById('invite_h264').checked=false;" /><label for="invite_vp9"> <span data-translate="force-vp9-video-codec">VP9 Video Codec</span></label>
 	<br />

--- a/index.html
+++ b/index.html
@@ -781,7 +781,7 @@
 							<div class="invite_setting_item">
 								<input type="checkbox" id="invite_bitrate" />
 								<label for="invite_bitrate">
-									<span data-translate="unlock-video-bitrate" title="Ideal for 1080p60 gaming, if your computer and upload are up for it" >Unlock the video bitrate (20mbps)</span>
+									<span data-translate="unlock-video-bitrate" title="Ideal for 1080p60 gaming, if your computer and upload are up for it" >Unlock the video bitrate (20 Mbps)</span>
 								</label>
 							</div>
 							<div class="invite_setting_item">

--- a/results.html
+++ b/results.html
@@ -454,8 +454,8 @@
 					
 					if (data.summary){
 						if (data.summary.download && data.summary.upload){
-							document.getElementById("details").innerHTML += "<br /><b>Max download bandwidth:</b> "+parseInt(data.summary.download/(1024*1024))+"-mbps<br />";
-							document.getElementById("details").innerHTML += "<br /><b>Max Upload bandwidth:</b> "+parseInt(data.summary.upload/(1024*1024))+"-mbps<br />";
+							document.getElementById("details").innerHTML += "<br /><b>Max download bandwidth:</b> "+parseInt(data.summary.download/(1024*1024))+"-Mbps<br />";
+							document.getElementById("details").innerHTML += "<br /><b>Max Upload bandwidth:</b> "+parseInt(data.summary.upload/(1024*1024))+"-Mbps<br />";
 						}
 					}
 					//if (data.scores && data.scores.gaming && data.scores.gaming.classificationName && data.scores.rtc && data.scores.rtc.classificationName && data.scores.streaming && data.scores.streaming.classificationName){

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "إظهار الفيديوهات بتدرج",
     "animate-mixing": "تحريك المزج",
     "add-margin": "إضافة هامش للفيديوهات",
-    "unlock-video-bitrate": "رفع قيود معدل البت (20mbps)",
+    "unlock-video-bitrate": "رفع قيود معدل البت (20 Mbps)",
     "disable-downscaling": "زيادة الوضوح",
     "force-mono-audio": "فرض الصوت الأحادي",
     "show-director": "Include Director",

--- a/translations/blank.json
+++ b/translations/blank.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "Unlock Video Bitrate (20mbps)",
+    "unlock-video-bitrate": "Unlock Video Bitrate (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",

--- a/translations/cn.json
+++ b/translations/cn.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "视频淡入效果",
     "animate-mixing": "动画合成",
     "add-margin": "添加视频边框",
-    "unlock-video-bitrate": "解锁视频比特率 (20mbps)",
+    "unlock-video-bitrate": "解锁视频比特率 (20 Mbps)",
     "disable-downscaling": "禁用降低分辨率",
     "force-mono-audio": "强制使用单声道音频",
     "show-director": "包含导演画面",

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "Rozvolnit limit Video Bitrate (20mbps)",
+    "unlock-video-bitrate": "Rozvolnit limit Video Bitrate (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",

--- a/translations/de.json
+++ b/translations/de.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "Video-Bitrate auf Maximum (20mbps)",
+    "unlock-video-bitrate": "Video-Bitrate auf Maximum (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",

--- a/translations/en.json
+++ b/translations/en.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "Unlock Video Bitrate (20mbps)",
+    "unlock-video-bitrate": "Unlock Video Bitrate (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",

--- a/translations/es.json
+++ b/translations/es.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fundir entrada de video",
     "animate-mixing": "Animar",
     "add-margin": "Añadir márgenes para los videos",
-    "unlock-video-bitrate": "Desbloquear Bitrate de Video (20mbps)",
+    "unlock-video-bitrate": "Desbloquear Bitrate de Video (20 Mbps)",
     "disable-downscaling": "Aumentar nitidez",
     "force-mono-audio": "Forzar audio mono",
     "show-director": "Incluir al Director",

--- a/translations/eu.json
+++ b/translations/eu.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Lausotu bideoak",
     "animate-mixing": "Animate mixing",
     "add-margin": "Jarri marjinak bideoei",
-    "unlock-video-bitrate": "Desblokeatu bideoaren bitrate-a (20mbps)",
+    "unlock-video-bitrate": "Desblokeatu bideoaren bitrate-a (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Behartu mono audioa",
     "show-director": "Include Director",

--- a/translations/it.json
+++ b/translations/it.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Dissolvenza in entrata dei video",
     "animate-mixing": "Animazione del missaggio",
     "add-margin": "Aggiungi margine ai video",
-    "unlock-video-bitrate": "Sblocca Video Bitrate (20mbps)",
+    "unlock-video-bitrate": "Sblocca Video Bitrate (20 Mbps)",
     "disable-downscaling": "Aumenta la nitidezza",
     "force-mono-audio": "Forza audio mono",
     "show-director": "Includi regista",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "ビデオビットレートをアンロック (20mbps)",
+    "unlock-video-bitrate": "ビデオビットレートをアンロック (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "Verwijder limitatie video bitrate (20mbps)",
+    "unlock-video-bitrate": "Verwijder limitatie video bitrate (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",

--- a/translations/pig.json
+++ b/translations/pig.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "ade videos inFay",
     "animate-mixing": "imate mixingAnay",
     "add-margin": "argin to videosAdd may",
-    "unlock-video-bitrate": "ock Video Bitrate (20mbps)Unlay",
+    "unlock-video-bitrate": "ock Video Bitrate (20 Mbps)Unlay",
     "disable-downscaling": "ease sharpnessIncray",
     "force-mono-audio": "orce mono audioFay",
     "show-director": "Include Director",

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Exibir vídeos gradualmente",
     "animate-mixing": "Mistura de animação",
     "add-margin": "Adicionar margem aos vídeos",
-    "unlock-video-bitrate": "Desbloquear taxa de bits de vídeo (20mbps)",
+    "unlock-video-bitrate": "Desbloquear taxa de bits de vídeo (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Forçar áudio mono",
     "show-director": "Include Director",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Desvanecer entrada de vídeos",
     "animate-mixing": "Animar mistura",
     "add-margin": "Adicionar margem aos vídeos",
-    "unlock-video-bitrate": "Desbloquear Bitrate de Vídeo (20mbps)",
+    "unlock-video-bitrate": "Desbloquear Bitrate de Vídeo (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Forçar áudio mono",
     "show-director": "Include Director",

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "Video Bitrate Sınırını Kaldır (20mbps)",
+    "unlock-video-bitrate": "Video Bitrate Sınırını Kaldır (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -61,7 +61,7 @@
     "fade-videos-in": "Fade videos in",
     "animate-mixing": "Animate mixing",
     "add-margin": "Add margin to videos",
-    "unlock-video-bitrate": "Дозволити відео бітрейт (20mbps)",
+    "unlock-video-bitrate": "Дозволити відео бітрейт (20 Mbps)",
     "disable-downscaling": "Increase sharpness",
     "force-mono-audio": "Force mono audio",
     "show-director": "Include Director",


### PR DESCRIPTION
Fixes something small that always irritated me when using the site, mbps (millibits per second) should be Mbps (megabits per second).